### PR TITLE
Added outline for polygons.

### DIFF
--- a/src/main/java/GisVisualization.java
+++ b/src/main/java/GisVisualization.java
@@ -26,6 +26,8 @@ public class GisVisualization {
     private GeometryModel geometryModel;
     private ArrayList<Circle> tooltips;
 
+    private static final float OPACITY_PARAM = 0.7f;
+
     public GisVisualization(final double canvasWidth,
                             final double canvasHeight,
                             final Geometry geometry,
@@ -62,7 +64,7 @@ public class GisVisualization {
                                                        final Geometry geometry,
                                                        final AnchorPane group) {
         GisVisualization gisVis = new GisVisualization(canvasWidth, canvasHeight, geometry, group);
-        gisVis.create2DShape(getRandomColor(0.7f));
+        gisVis.create2DShape(getRandomColor(OPACITY_PARAM));
         group.getChildren().add(gisVis.canvas);
 
         return gisVis;

--- a/src/main/java/GisVisualization.java
+++ b/src/main/java/GisVisualization.java
@@ -62,7 +62,7 @@ public class GisVisualization {
                                                        final Geometry geometry,
                                                        final AnchorPane group) {
         GisVisualization gisVis = new GisVisualization(canvasWidth, canvasHeight, geometry, group);
-        gisVis.create2DShape(getRandomColor(1.0f));
+        gisVis.create2DShape(getRandomColor(0.7f));
         group.getChildren().add(gisVis.canvas);
 
         return gisVis;

--- a/src/main/java/models/PolygonModel.java
+++ b/src/main/java/models/PolygonModel.java
@@ -5,6 +5,7 @@ import com.vividsolutions.jts.geom.Geometry;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.shape.Circle;
 
 import java.util.ArrayList;
@@ -32,6 +33,11 @@ public class PolygonModel extends GeometryModel {
         }
 
         graphicsContext.fillPolygon(xCoordinates, yCoordinates, coordinates.length);
+        graphicsContext.setStroke(((Color)graphicsContext.getFill()).darker());
+        for (int i = 1; i < coordinates.length; i++) {
+            graphicsContext.strokeLine(coordinates[i - 1].x, coordinates[i - 1].y,
+                    coordinates[i].x, coordinates[i].y);
+        }
 
         return tooltips;
     }

--- a/src/main/java/models/PolygonModel.java
+++ b/src/main/java/models/PolygonModel.java
@@ -5,7 +5,6 @@ import com.vividsolutions.jts.geom.Geometry;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import javafx.scene.shape.Circle;
 
 import java.util.ArrayList;
@@ -33,7 +32,7 @@ public class PolygonModel extends GeometryModel {
         }
 
         graphicsContext.fillPolygon(xCoordinates, yCoordinates, coordinates.length);
-        graphicsContext.setStroke(((Color)graphicsContext.getFill()).darker());
+        graphicsContext.setStroke(((Color) graphicsContext.getFill()).darker());
         for (int i = 1; i < coordinates.length; i++) {
             graphicsContext.strokeLine(coordinates[i - 1].x, coordinates[i - 1].y,
                     coordinates[i].x, coordinates[i].y);


### PR DESCRIPTION
PolygonModel.java now uses the javafx color method Color.darker as the strokefill, and uses the same coordinates to draw lines between points (the same way linestring do). Only problem is there will be one uneccessary line connecting the outer and inner line in the case where polygons have holes in them. Not sure it is worth the effort to fix.
