### PR TITLE
All layers are now drawn on same canvas [FIXED]

### DIFF
--- a/src/main/java/Controller.java
+++ b/src/main/java/Controller.java
@@ -20,7 +20,6 @@ import org.geotools.geometry.jts.JTSFactoryFinder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 public class Controller {
     /**
@@ -81,7 +80,7 @@ public class Controller {
         }
     }
 
-    public final void drawGeometry(final Geometry geom, String poly) {
+    public final void drawGeometry(final Geometry geom, final String poly) {
         if (geom instanceof GeometryCollection) {
             for (int i = 0; i < geom.getNumGeometries(); i++) {
                 refineGeometryClass(geom.getGeometryN(i), poly);
@@ -94,12 +93,11 @@ public class Controller {
     /**
      * Displays an alert dialog when trying to draw an invalid WKT string.
      */
-    public final void showWKTParseErrorMessage()
-    {
+    public final void showWKTParseErrorMessage() {
         Alert alert = new Alert(Alert.AlertType.ERROR);
         alert.setTitle("Error parsing WKT");
         alert.setHeaderText("Invalid WKT");
-        String s ="The WKT string entered is of unknown geometry type ";
+        String s = "The WKT string entered is of unknown geometry type ";
         alert.setContentText(s);
         alert.show();
     }
@@ -109,7 +107,7 @@ public class Controller {
      * or a composite such as a MultiPolygon.
      * @param geometry geometry to consider.
      */
-    private void refineGeometryClass(final Geometry geometry, String poly) {
+    private void refineGeometryClass(final Geometry geometry, final String poly) {
         if (geometry instanceof GeometryCollection) {
             createLayersFromMultiples(geometry, poly);
         } else {
@@ -121,7 +119,7 @@ public class Controller {
      * Assumes the given geometry is of a multiple type, and creates a layer for each.
      * @param geometry geometry to consider.
      */
-    private void createLayersFromMultiples(final Geometry geometry, String poly) {
+    private void createLayersFromMultiples(final Geometry geometry, final String poly) {
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
             createLayer(geometry.getGeometryN(i), poly);
         }
@@ -131,7 +129,7 @@ public class Controller {
      * Creates a layer for the given geometry.
      * @param geometry geometry to draw to a layer.
      */
-    private void createLayer(final Geometry geometry, String poly) {
+    private void createLayer(final Geometry geometry, final String poly) {
         GisVisualization gv = GisVisualization.createVisualization(
                 geometry,
                 upperPane);

--- a/src/main/java/Controller.java
+++ b/src/main/java/Controller.java
@@ -5,6 +5,7 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.WKTReader;
 import javafx.fxml.FXML;
 import javafx.scene.Cursor;
+import javafx.scene.control.Alert;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -78,32 +79,43 @@ public class Controller {
             WKTReader reader = new WKTReader(geometryFactory);
             Geometry geom = reader.read(poly);
 
-            drawPolygon(geom);
+            drawGeometry(geom, poly);
             rescaleAllGeometries();
         } catch (com.vividsolutions.jts.io.ParseException e) {
-            e.printStackTrace();
+            showWKTParseErrorMessage();
         }
     }
 
-    public final void drawPolygon(final Geometry geom) {
+    public final void drawGeometry(final Geometry geom, String poly) {
         if (geom instanceof GeometryCollection) {
             for (int i = 0; i < geom.getNumGeometries(); i++) {
-                refineGeometryClass(geom.getGeometryN(i));
+                refineGeometryClass(geom.getGeometryN(i), poly);
             }
         } else {
-            refineGeometryClass(geom);
+            refineGeometryClass(geom, poly);
         }
     }
+
+    public final void showWKTParseErrorMessage()
+    {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setTitle("Error parsing WKT");
+        alert.setHeaderText("Invalid WKT");
+        String s ="The WKT string entered is of unknown geometry type ";
+        alert.setContentText(s);
+        alert.show();
+    }
+
     /**
      * Delegates the task of creating the layer for this geometry. Whether it is a plain WKT object,
      * or a composite such as a MultiPolygon.
      * @param geometry geometry to consider.
      */
-    private void refineGeometryClass(final Geometry geometry) {
+    private void refineGeometryClass(final Geometry geometry, String poly) {
         if (geometry instanceof GeometryCollection) {
-            createLayersFromMultiples(geometry);
+            createLayersFromMultiples(geometry, poly);
         } else {
-            createLayer(geometry);
+            createLayer(geometry, poly);
         }
     }
 
@@ -111,9 +123,9 @@ public class Controller {
      * Assumes the given geometry is of a multiple type, and creates a layer for each.
      * @param geometry geometry to consider.
      */
-    private void createLayersFromMultiples(final Geometry geometry) {
+    private void createLayersFromMultiples(final Geometry geometry, String poly) {
         for (int i = 0; i < geometry.getNumGeometries(); i++) {
-            createLayer(geometry.getGeometryN(i));
+            createLayer(geometry.getGeometryN(i), poly);
         }
     }
 
@@ -121,14 +133,14 @@ public class Controller {
      * Creates a layer for the given geometry.
      * @param geometry geometry to draw to a layer.
      */
-    private void createLayer(final Geometry geometry) {
+    private void createLayer(final Geometry geometry, String poly) {
         GisVisualization gv = GisVisualization.createVisualization(
                 this.stage.getWidth(),
                 this.stage.getHeight(),
                 geometry,
                 upperPane);
         gisVisualizations.add(gv);
-        Layer hb = new Layer(gv, vboxLayers, geometry.getGeometryType());
+        Layer hb = new Layer(gv, vboxLayers, geometry.getGeometryType(), poly, queryInput);
         Layer.getLayers().add(hb);
         hb.reorderLayers();
         upperPane.requestFocus();
@@ -157,23 +169,14 @@ public class Controller {
         }
     }
 
-    // TODO
-    // Concerns: dragging only works when clicking the canvas,
-    // areas of pane not filled with canvas does not react
-    // Possible solutions: Make a really huge canvas and translate
-    // 0,0 to middle of screen. Or find another node and listener to move canvas
-
     public final void rescaleAllGeometries() {
         double currentZoom = Math.pow(ZOOM_FACTOR, currentZoomLevel); // ZOOM_FACTOR ^ ZOOM_LEVEL;
-        GisVisualization gv;
 
         // resize and redraw all geometries
-        for (int i = 0; i < gisVisualizations.size(); i++) {
-            gv = (GisVisualization) gisVisualizations.get(i);
-
-            resizeGeometryModel(gv.getGeometryModel(), currentZoom);
+        for (GisVisualization gisVisualization : gisVisualizations) {
+            resizeGeometryModel(gisVisualization.getGeometryModel(), currentZoom);
             // redraw
-            gisVisualizations.get(i).reDraw();
+            gisVisualization.reDraw();
         }
         // reorder layers to maintain tooltips display correctly
         if (!Layer.getLayers().isEmpty()) {
@@ -211,10 +214,6 @@ public class Controller {
             zoomIn();
         }
     }
-    //TODO Concerns: dragging only works when clicking the canvas,
-        //areas of pane not filled with canvas does not react
-    //TODO possible solutions: Make a really huge canvas and translate 0,0 to middle of screen.
-        // Or find another node and listener to move canvas
 
     /**
      * Called when the mouse press the upperPane.
@@ -248,23 +247,6 @@ public class Controller {
         this.stage.getScene().setCursor(Cursor.DEFAULT);
     }
 
-
-
-    /*private Node isChildFocused(final Parent parent) {
-        for (Node node : parent.getChildrenUnmodifiable()) {
-            if (node.isFocused()) {
-                return node;
-            } else if (node instanceof Parent) {
-                if (isChildFocused((Parent) node) != null) {
-                    return node;
-                }
-            }
-        }
-        return null;
-    }*/
-
-
-
     public final void wktAreaKeyPressed(final KeyEvent event) {
         if (event.isAltDown() && event.getCode() == KeyCode.ENTER) {
             pressed();
@@ -276,7 +258,6 @@ public class Controller {
             heldDownKeys.add(event.getCode());
         }
     }
-
 
     public final void onAnyKeyReleased(final KeyEvent event) {
         heldDownKeys.remove(event.getCode());

--- a/src/main/java/GisVisualization.java
+++ b/src/main/java/GisVisualization.java
@@ -1,6 +1,7 @@
 import com.vividsolutions.jts.geom.Geometry;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
@@ -15,29 +16,31 @@ import java.util.ArrayList;
 public class GisVisualization {
 
     private static int idCounter = 0;       //Static counter for IDs
-    private AnchorPane group;         //Root node all canvases will be drawn to
+    private static AnchorPane group;        //Root node all canvases will be drawn to
+
+    private static int CANVAS_WIDTH = 5000;
+    private static int CANVAS_HEIGHT = 5000;
+    private static final float OPACITY_PARAM = 0.7f;
+    private static Canvas canvas;
+    private static GraphicsContext graphicsContext;
 
     private int id;
-
-    private Canvas canvas;
-    private GraphicsContext graphicsContext;
+    private Color color;
     private GeometryModel geometryModel;
     private ArrayList<Circle> tooltips;
+    private ArrayList<Circle> originalTooltips;
 
     private static ArrayList<Color> colors = new ArrayList<>();
 
-    public GisVisualization(final double canvasWidth,
-                            final double canvasHeight,
-                            final Geometry geometry,
+    public GisVisualization(final Geometry geometry,
                             final AnchorPane group) {
         this.id = idCounter;
         incrementCounter();
-        this.group = group;
-        this.canvas = new Canvas(canvasWidth, canvasHeight);
-        this.graphicsContext = canvas.getGraphicsContext2D();
+        createCanvas(group);
         this.geometryModel = GeometryModel.getModel(geometry, group);
         this.tooltips = new ArrayList<>();
         initColors();
+        this.color = getColor(this.id);
     }
 
     private static void initColors() {
@@ -54,64 +57,39 @@ public class GisVisualization {
         return this.geometryModel;
     }
 
-    private static void incrementCounter() {
-        GisVisualization.idCounter += 1;
-    }
-
-    public final AnchorPane getGroup() {
-        return this.group;
-    }
-
-    public final GraphicsContext getGraphicsContext() {
-        return this.graphicsContext;
-    }
-
-    public final void clearGraphicsContext() {
-        this.canvas.getGraphicsContext2D().clearRect(0, 0,
-                this.canvas.getWidth(),
-                this.canvas.getHeight());
-        this.setDisplayTooltips(false);
-        tooltips.clear();
-    }
-
-    public final void reDraw() {
-        this.clearGraphicsContext();
-        ArrayList<Circle> partialTooltips =
-                this.geometryModel.drawAndCreateToolTips(this.graphicsContext);
-        tooltips.addAll(partialTooltips);
+    /**
+     * Creates a canvas, graphicsContext and fixes all setup required for drawing geometries.
+     * This will only happen the first time a layer is setup, and will be ignored on all subsequent layer creations.
+     * @param group The parent container in the drawing window.
+     */
+    private static void createCanvas(AnchorPane group)
+    {
+        if (canvas == null)
+        {
+            canvas = new Canvas(CANVAS_WIDTH, CANVAS_HEIGHT);
+            graphicsContext = canvas.getGraphicsContext2D();
+            group.getChildren().add(canvas);
+            GisVisualization.group = group;
+        }
     }
 
     /**
-     * Creates a polygon from the given points and draw it on the canvas.
-     * Also creates tooltips for each point in the polygon.
+     * Creates a geometry from the given points and draw it on the canvas.
+     * Also creates tooltips for each point in the geometry.
      *
-     * @param canvasWidth  Width of the canvas the GIS-visualization will drawn to.
-     * @param canvasHeight Height of the canvas the GIS-visualization will drawn to.
      * @param geometry      The geometry object to visualize.
      * @param group         The group the polygon will be drawn at.
      * @return a GisVisualization object.
      */
-    public static GisVisualization createVisualization(final double canvasWidth,
-                                                       final double canvasHeight,
-                                                       final Geometry geometry,
+    public static GisVisualization createVisualization(final Geometry geometry,
                                                        final AnchorPane group) {
-        GisVisualization gisVis = new GisVisualization(canvasWidth, canvasHeight, geometry, group);
-        gisVis.create2DShape(getColor(gisVis.getID()));
-        group.getChildren().add(gisVis.canvas);
+        GisVisualization gisVis = new GisVisualization(geometry, group);
+        gisVis.create2DShapeAndTooltips();
 
         return gisVis;
     }
 
-
-    /**
-     * Redraws this GisVisualization object and tooltips to its given group.
-     */
-    public final void reAddCanvas() {
-        group.getChildren().add(this.canvas);
-    }
-
     public final void setDisplayTooltips(final boolean display) {
-        //group.getChildren().remove(0, group.getChildren().size());
         if (display) {
             for (Circle c : tooltips) {
                 group.getChildren().add(c);
@@ -124,31 +102,54 @@ public class GisVisualization {
     }
 
     /**
-     * Creates a polygon using this GisVisualization object's graphicsContext.
-     * @param color The color of the polygon
+     * Reset the canvas.
+     * Removes all elements in the plot view. Including tooltips and canvas.
+     * Then adds the canvas again, and clears its contents.
      */
-    private void create2DShape(final Color color) {
-
-        this.graphicsContext.setFill(color);
-        this.graphicsContext.setStroke(color);
-
-        //This GisVisualization object can contain any geometry
-        //There check its instance and draw accordingly
-
-        ArrayList<Circle> partialTooltips =
-                geometryModel.drawAndCreateToolTips(this.graphicsContext);
-
-        tooltips.addAll(partialTooltips);
+    public static void reset()
+    {
+        group.getChildren().clear();
+        group.getChildren().add(GisVisualization.getCanvas());
+        graphicsContext.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
     }
 
-    public final void toggleVisibility() {
-        this.canvas.setVisible(!canvas.isVisible());
-        for (Circle c : this.tooltips) {
-            c.setVisible(canvas.isVisible());
+    /**
+     * Creates a geometry using the geometryModel class to delegate the drawing according to type.
+     * Also creates tooltips and copies them in an original tooltip list
+     */
+    public final void create2DShapeAndTooltips() {
+        tooltips.clear();
+        graphicsContext.setFill(this.color);
+        graphicsContext.setStroke(this.color);
+
+        tooltips.addAll(geometryModel.drawAndCreateToolTips(graphicsContext));
+        originalTooltips = cloneList(tooltips);
+    }
+
+    /**
+     * creates a geometry, but does not handle anything about its tooltips.
+     */
+    public final void redraw2DShape() {
+        graphicsContext.setFill(this.color);
+        graphicsContext.setStroke(this.color);
+
+        geometryModel.drawAndCreateToolTips(graphicsContext);
+    }
+
+    /**
+     * Moves the tooltips to accommodate for any zoom.
+     * Tooltips are always scaled based on their original value to avoid decimal errors
+     * Moved tooltips are added to the scene
+     * @param zoomFactor    The ratio of zoom to be applied
+     */
+    public final void moveTooltips(double zoomFactor)
+    {
+        for (int i = 0; i < tooltips.size(); i++)
+        {
+            tooltips.get(i).setCenterX(originalTooltips.get(i).getCenterX()*zoomFactor);
+            tooltips.get(i).setCenterY(originalTooltips.get(i).getCenterY()*zoomFactor);
         }
     }
-
-    private static final float OPACITY_PARAM = 0.7f;
 
     /**
      * Returns the next layer color with provided opacity.
@@ -160,7 +161,6 @@ public class GisVisualization {
         return Color.web(colorString, OPACITY_PARAM);
 }
 
-
     /**
      * Get the ID for this GisVisualization object.
      *
@@ -170,4 +170,35 @@ public class GisVisualization {
         return this.id;
     }
 
+    /**
+     * Get the canvas used to draw all geometries.
+     * This is the same for all layers.
+     * @return  The canvas.
+     */
+    public static Canvas getCanvas()
+    {
+        return canvas;
+    }
+
+    public static AnchorPane getGroup()
+    {
+        return group;
+    }
+
+    public ArrayList<Circle> getTooltips()
+    {
+        return this.tooltips;
+    }
+
+    private static void incrementCounter() {
+        GisVisualization.idCounter += 1;
+    }
+
+    public static ArrayList<Circle> cloneList(ArrayList<Circle> circles) {
+       ArrayList<Circle> clonedList = new ArrayList<Circle>(circles.size());
+        for (Circle c : circles) {
+            clonedList.add(new Circle(c.getCenterX(), c.getCenterY(), c.getRadius(), c.getFill()));
+        }
+        return clonedList;
+    }
 }

--- a/src/main/java/GisVisualization.java
+++ b/src/main/java/GisVisualization.java
@@ -1,7 +1,6 @@
 import com.vividsolutions.jts.geom.Geometry;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
@@ -18,8 +17,8 @@ public class GisVisualization {
     private static int idCounter = 0;       //Static counter for IDs
     private static AnchorPane group;        //Root node all canvases will be drawn to
 
-    private static int CANVAS_WIDTH = 5000;
-    private static int CANVAS_HEIGHT = 5000;
+    private static final int CANVAS_WIDTH = 5000;
+    private static final int CANVAS_HEIGHT = 5000;
     private static final float OPACITY_PARAM = 0.7f;
     private static Canvas canvas;
     private static GraphicsContext graphicsContext;
@@ -59,13 +58,12 @@ public class GisVisualization {
 
     /**
      * Creates a canvas, graphicsContext and fixes all setup required for drawing geometries.
-     * This will only happen the first time a layer is setup, and will be ignored on all subsequent layer creations.
+     * This will only happen the first time a layer is setup,
+     * and will be ignored on all subsequent layer creations.
      * @param group The parent container in the drawing window.
      */
-    private static void createCanvas(AnchorPane group)
-    {
-        if (canvas == null)
-        {
+    private static void createCanvas(AnchorPane group) {
+        if (canvas == null) {
             canvas = new Canvas(CANVAS_WIDTH, CANVAS_HEIGHT);
             graphicsContext = canvas.getGraphicsContext2D();
             group.getChildren().add(canvas);
@@ -106,8 +104,7 @@ public class GisVisualization {
      * Removes all elements in the plot view. Including tooltips and canvas.
      * Then adds the canvas again, and clears its contents.
      */
-    public static void reset()
-    {
+    public static void reset() {
         group.getChildren().clear();
         group.getChildren().add(GisVisualization.getCanvas());
         graphicsContext.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
@@ -142,12 +139,11 @@ public class GisVisualization {
      * Moved tooltips are added to the scene
      * @param zoomFactor    The ratio of zoom to be applied
      */
-    public final void moveTooltips(double zoomFactor)
-    {
+    public final void moveTooltips(final double zoomFactor) {
         for (int i = 0; i < tooltips.size(); i++)
         {
-            tooltips.get(i).setCenterX(originalTooltips.get(i).getCenterX()*zoomFactor);
-            tooltips.get(i).setCenterY(originalTooltips.get(i).getCenterY()*zoomFactor);
+            tooltips.get(i).setCenterX(originalTooltips.get(i).getCenterX() * zoomFactor);
+            tooltips.get(i).setCenterY(originalTooltips.get(i).getCenterY() * zoomFactor);
         }
     }
 
@@ -175,18 +171,15 @@ public class GisVisualization {
      * This is the same for all layers.
      * @return  The canvas.
      */
-    public static Canvas getCanvas()
-    {
+    public static Canvas getCanvas() {
         return canvas;
     }
 
-    public static AnchorPane getGroup()
-    {
+    public static AnchorPane getGroup() {
         return group;
     }
 
-    public ArrayList<Circle> getTooltips()
-    {
+    public final ArrayList<Circle> getTooltips() {
         return this.tooltips;
     }
 
@@ -194,7 +187,7 @@ public class GisVisualization {
         GisVisualization.idCounter += 1;
     }
 
-    public static ArrayList<Circle> cloneList(ArrayList<Circle> circles) {
+    public static ArrayList<Circle> cloneList(final ArrayList<Circle> circles) {
        ArrayList<Circle> clonedList = new ArrayList<Circle>(circles.size());
         for (Circle c : circles) {
             clonedList.add(new Circle(c.getCenterX(), c.getCenterY(), c.getRadius(), c.getFill()));

--- a/src/main/java/GisVisualization.java
+++ b/src/main/java/GisVisualization.java
@@ -62,7 +62,7 @@ public class GisVisualization {
      * and will be ignored on all subsequent layer creations.
      * @param group The parent container in the drawing window.
      */
-    private static void createCanvas(AnchorPane group) {
+    private static void createCanvas(final AnchorPane group) {
         if (canvas == null) {
             canvas = new Canvas(CANVAS_WIDTH, CANVAS_HEIGHT);
             graphicsContext = canvas.getGraphicsContext2D();
@@ -140,8 +140,7 @@ public class GisVisualization {
      * @param zoomFactor    The ratio of zoom to be applied
      */
     public final void moveTooltips(final double zoomFactor) {
-        for (int i = 0; i < tooltips.size(); i++)
-        {
+        for (int i = 0; i < tooltips.size(); i++) {
             tooltips.get(i).setCenterX(originalTooltips.get(i).getCenterX() * zoomFactor);
             tooltips.get(i).setCenterY(originalTooltips.get(i).getCenterY() * zoomFactor);
         }

--- a/src/main/java/Layer.java
+++ b/src/main/java/Layer.java
@@ -142,8 +142,7 @@ public class Layer extends HBox {
     private static ArrayList<Layer> getAllSelectedLayers() {
         ArrayList<Layer> selectedLayers = new ArrayList<>();
         for (Layer l : layers) {
-            if (l.isSelected.get())
-            {
+            if (l.isSelected.get()) {
                 selectedLayers.add(l);
             }
         }

--- a/src/main/java/Layer.java
+++ b/src/main/java/Layer.java
@@ -5,6 +5,7 @@ import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -41,15 +42,20 @@ public class Layer extends HBox {
     private Button buttonUp;            //Button for moving layer up a layer
     private Button buttonDown;          //Button for moving layer down a layer
     private String name;                //Name of the layers
+    private String WKTString;           //Original WKT string entered for this layer
+    private TextArea textArea;          //The textarea callback used for showing this layer's WKT string
     private LayerSelectedProperty isSelected;
 
     private static ArrayList<Layer> layers = new ArrayList<>();
 
-    public Layer(final GisVisualization gisVis, final VBox parentContainer, final String name) {
+    public Layer(final GisVisualization gisVis, final VBox parentContainer, final String name,
+                 final String WKTString, final TextArea textArea) {
         this.gisVis = gisVis;
         this.orderID = gisVis.getID();
         this.parentContainer = parentContainer;
         this.name = name;
+        this.WKTString = WKTString;
+        this.textArea = textArea;
         this.isSelected = new LayerSelectedProperty();
         this.setOnMouseClicked(mouseClickedHandler);
         this.setOnKeyReleased(keyReleasedHandler);
@@ -102,11 +108,35 @@ public class Layer extends HBox {
             isSelected.set(!oldValue);
             gisVis.setDisplayTooltips(isSelected.get());
             if (isSelected.get()) {
+                showWKTString();
                 requestFocus();
+            }
+            else
+            {
+                int numberOfSelected = 0;
+                Layer selectedLayer = null;
+                for (Layer l : layers)
+                {
+                    if (l.isSelected.get())
+                    {
+                        selectedLayer = l;
+                        numberOfSelected++;
+                    }
+                }
+                if (numberOfSelected == 1)
+                {
+                     selectedLayer.showWKTString();
+                }
             }
             toggleBackgroundColor(isSelected);
         }
     };
+
+    private void showWKTString()
+    {
+        textArea.clear();
+        textArea.setText(WKTString);
+    }
 
     private void toggleBackgroundColor(final BooleanProperty val) {
         backgroundProperty().bind(Bindings.when(val)

--- a/src/main/java/Layer.java
+++ b/src/main/java/Layer.java
@@ -29,18 +29,18 @@ public class Layer extends HBox {
     private final GisVisualization gisVis;     //The drawing model
     private final VBox parentContainer;        //Container where layers are put
     private String name;                       //Name of the layers
-    private String WKTString;                  //Original WKT string entered for this layer
-    private TextArea textArea;                 //The textarea callback used for showing this layer's WKT string
+    private String wktString;                  //Original WKT string entered for this layer
+    private TextArea textArea;
     private LayerSelectedProperty isSelected;
     private CheckBox showOrHideCheckbox;
     private static ArrayList<Layer> layers = new ArrayList<>();
 
     public Layer(final GisVisualization gisVis, final VBox parentContainer, final String name,
-                 final String WKTString, final TextArea textArea) {
+                 final String wktString, final TextArea textArea) {
         this.gisVis = gisVis;
         this.parentContainer = parentContainer;
         this.name = name;
-        this.WKTString = WKTString;
+        this.wktString = wktString;
         this.textArea = textArea;
         this.isSelected = new LayerSelectedProperty();
         this.setOnMouseClicked(mouseClickedHandler);
@@ -100,22 +100,24 @@ public class Layer extends HBox {
 
             int numberOfSelectedLayers = getNumberOfSelectedLayers();
 
-            if (numberOfSelectedLayers == 0)
+            if (numberOfSelectedLayers == 0) {
                 textArea.clear();
+            }
 
-            else if (numberOfSelectedLayers == 1)
+            else if (numberOfSelectedLayers == 1) {
                 getAllSelectedLayers().get(0).showWKTString();
+            }
 
-            else if (numberOfSelectedLayers > 1)
+            else if (numberOfSelectedLayers > 1) {
                 textArea.setDisable(true);
+            }
 
 
             toggleBackgroundColor(isSelected);
         }
     };
 
-    public boolean getIfTooltipsShouldBeDisplayed()
-    {
+    public final boolean getIfTooltipsShouldBeDisplayed() {
         return isSelected.get() && showOrHideCheckbox.isSelected();
     }
 
@@ -123,13 +125,10 @@ public class Layer extends HBox {
      * Returns the number of selected layers whose selected property is true.
      * @return number of selected layers.
      */
-    private static int getNumberOfSelectedLayers()
-    {
+    private static int getNumberOfSelectedLayers() {
         int numberOfSelected = 0;
-        for (Layer l : layers)
-        {
-            if (l.isSelected.get())
-            {
+        for (Layer l : layers) {
+            if (l.isSelected.get()) {
                 numberOfSelected++;
             }
         }
@@ -140,11 +139,9 @@ public class Layer extends HBox {
      * Returns a list of selected layers.
      * @return the list.
      */
-    private static ArrayList<Layer> getAllSelectedLayers()
-    {
+    private static ArrayList<Layer> getAllSelectedLayers() {
         ArrayList<Layer> selectedLayers = new ArrayList<>();
-        for (Layer l : layers)
-        {
+        for (Layer l : layers) {
             if (l.isSelected.get())
             {
                 selectedLayers.add(l);
@@ -168,10 +165,9 @@ public class Layer extends HBox {
     /**
      * Clears the WKT input text area and displays the WKT string used to draw this layer.
      */
-    private void showWKTString()
-    {
+    private void showWKTString() {
         textArea.clear();
-        textArea.setText(WKTString);
+        textArea.setText(wktString);
     }
 
     /**
@@ -250,8 +246,7 @@ public class Layer extends HBox {
      * Redraws all geometries to the canvas, in the same order as they appear in the layer view.
      * The bottom layer is drawn at the bottom of the drawing stack.
      */
-    public static void redrawAll()
-    {
+    public static void redrawAll() {
         GisVisualization.reset();
 
         for (int i = layers.size() - 1; i >= 0; i--) {
@@ -267,8 +262,7 @@ public class Layer extends HBox {
      * Checks or unchecks all the selected layers.
      * This is useful for showing/hiding several layers at once.
      */
-    private void checkShowOrHideCheckboxes()
-    {
+    private void checkShowOrHideCheckboxes() {
         if (isSelected.get()) {
             boolean checkedValue = showOrHideCheckbox.isSelected();
             for (Layer l : getAllSelectedLayers()) {
@@ -281,8 +275,7 @@ public class Layer extends HBox {
         return layers;
     }
 
-    public GisVisualization getGisVis()
-    {
+    public final GisVisualization getGisVis() {
         return this.gisVis;
     }
 

--- a/src/main/java/Layer.java
+++ b/src/main/java/Layer.java
@@ -102,13 +102,9 @@ public class Layer extends HBox {
 
             if (numberOfSelectedLayers == 0) {
                 textArea.clear();
-            }
-
-            else if (numberOfSelectedLayers == 1) {
+            } else if (numberOfSelectedLayers == 1) {
                 getAllSelectedLayers().get(0).showWKTString();
-            }
-
-            else if (numberOfSelectedLayers > 1) {
+            } else if (numberOfSelectedLayers > 1) {
                 textArea.setDisable(true);
             }
 

--- a/src/main/java/Layer.java
+++ b/src/main/java/Layer.java
@@ -3,13 +3,11 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
-import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
@@ -28,30 +26,18 @@ import java.util.Collections;
 
 public class Layer extends HBox {
 
-    //TODO style buttons with better representation, generally improve layer visuals
-    //TODO Make upper layer act as front layer
-    //TODO Make layers in layerview draggable
-    //TODO Todo enable selecting color
-    //TODO Suggestion: make layer hbox selectable, when selected show tooltips.
-
-
     private final GisVisualization gisVis;     //The drawing model
     private final VBox parentContainer;        //Container where layers are put
-
-    private int orderID;                //Defines the drawing order, highest value is drawn last
-    private Button buttonUp;            //Button for moving layer up a layer
-    private Button buttonDown;          //Button for moving layer down a layer
-    private String name;                //Name of the layers
-    private String WKTString;           //Original WKT string entered for this layer
-    private TextArea textArea;          //The textarea callback used for showing this layer's WKT string
+    private String name;                       //Name of the layers
+    private String WKTString;                  //Original WKT string entered for this layer
+    private TextArea textArea;                 //The textarea callback used for showing this layer's WKT string
     private LayerSelectedProperty isSelected;
-
+    private CheckBox showOrHideCheckbox;
     private static ArrayList<Layer> layers = new ArrayList<>();
 
     public Layer(final GisVisualization gisVis, final VBox parentContainer, final String name,
                  final String WKTString, final TextArea textArea) {
         this.gisVis = gisVis;
-        this.orderID = gisVis.getID();
         this.parentContainer = parentContainer;
         this.name = name;
         this.WKTString = WKTString;
@@ -62,8 +48,21 @@ public class Layer extends HBox {
         createLayer();
     }
 
-    public static ArrayList<Layer> getLayers() {
-        return layers;
+    /**
+     * Creates a layer for this Layer object.
+     */
+    public final void createLayer() {
+        showOrHideCheckbox = new CheckBox();
+        showOrHideCheckbox.setOnAction(event -> {
+            checkShowOrHideCheckboxes();
+            redrawAll();
+        });
+        showOrHideCheckbox.setSelected(true);
+        TextField tf = new TextField(this.name + " " + gisVis.getID());
+        VBox vb = new VBox();
+        this.getChildren().add(showOrHideCheckbox);
+        this.getChildren().add(tf);
+        this.getChildren().add(vb);
     }
 
     public final void deleteLayers() {
@@ -71,18 +70,89 @@ public class Layer extends HBox {
         layers.clear();
     }
 
-    private EventHandler<KeyEvent> keyReleasedHandler = new EventHandler<KeyEvent>() {
-        @Override
-        public void handle(final KeyEvent event) {
-            if (event.getCode() == KeyCode.DOWN) {
-                //Move selected layers down
-                moveSelectedLayers(1);
-            } else if (event.getCode() == KeyCode.UP) {
-                //Move selected layers up
-                moveSelectedLayers(-1);
-            }
+    private EventHandler<KeyEvent> keyReleasedHandler = event -> {
+        if (event.getCode() == KeyCode.DOWN) {
+            //Move selected layers down
+            moveSelectedLayers(1);
+        } else if (event.getCode() == KeyCode.UP) {
+            //Move selected layers up
+            moveSelectedLayers(-1);
         }
     };
+
+    private EventHandler<MouseEvent> mouseClickedHandler = new EventHandler<MouseEvent>() {
+        @Override
+        public void handle(final MouseEvent event) {
+            textArea.setDisable(false);
+            //CTRL is pressed select additional, otherwise unselected previously selected
+            boolean oldValue = isSelected.get();
+            if (!Controller.isKeyHeldDown(KeyCode.CONTROL)) {
+                deselectAllLayers();
+            }
+
+            //Toggle selection and display tooltips if it is selected
+            isSelected.set(!oldValue);
+            gisVis.setDisplayTooltips(getIfTooltipsShouldBeDisplayed());
+            if (isSelected.get()) {
+                showWKTString();
+                requestFocus();
+            }
+
+            int numberOfSelectedLayers = getNumberOfSelectedLayers();
+
+            if (numberOfSelectedLayers == 0)
+                textArea.clear();
+
+            else if (numberOfSelectedLayers == 1)
+                getAllSelectedLayers().get(0).showWKTString();
+
+            else if (numberOfSelectedLayers > 1)
+                textArea.setDisable(true);
+
+
+            toggleBackgroundColor(isSelected);
+        }
+    };
+
+    public boolean getIfTooltipsShouldBeDisplayed()
+    {
+        return isSelected.get() && showOrHideCheckbox.isSelected();
+    }
+
+    /**
+     * Returns the number of selected layers whose selected property is true.
+     * @return number of selected layers.
+     */
+    private static int getNumberOfSelectedLayers()
+    {
+        int numberOfSelected = 0;
+        for (Layer l : layers)
+        {
+            if (l.isSelected.get())
+            {
+                numberOfSelected++;
+            }
+        }
+        return numberOfSelected;
+    }
+
+    /**
+     * Returns a list of selected layers.
+     * @return the list.
+     */
+    private static ArrayList<Layer> getAllSelectedLayers()
+    {
+        ArrayList<Layer> selectedLayers = new ArrayList<>();
+        for (Layer l : layers)
+        {
+            if (l.isSelected.get())
+            {
+                selectedLayers.add(l);
+            }
+        }
+
+        return selectedLayers;
+    }
 
     /**
      * Deselects all layers, disables their tooltip and returns background color to normal.
@@ -95,49 +165,19 @@ public class Layer extends HBox {
         }
     }
 
-    private EventHandler<MouseEvent> mouseClickedHandler = new EventHandler<MouseEvent>() {
-        @Override
-        public void handle(final MouseEvent event) {
-            //CTRL is pressed select additional, otherwise unselected previously selected
-            boolean oldValue = isSelected.get();
-            if (!Controller.isKeyHeldDown(KeyCode.CONTROL)) {
-                deselectAllLayers();
-            }
-
-            //Toggle selection and display tooltips if it is selected
-            isSelected.set(!oldValue);
-            gisVis.setDisplayTooltips(isSelected.get());
-            if (isSelected.get()) {
-                showWKTString();
-                requestFocus();
-            }
-            else
-            {
-                int numberOfSelected = 0;
-                Layer selectedLayer = null;
-                for (Layer l : layers)
-                {
-                    if (l.isSelected.get())
-                    {
-                        selectedLayer = l;
-                        numberOfSelected++;
-                    }
-                }
-                if (numberOfSelected == 1)
-                {
-                     selectedLayer.showWKTString();
-                }
-            }
-            toggleBackgroundColor(isSelected);
-        }
-    };
-
+    /**
+     * Clears the WKT input text area and displays the WKT string used to draw this layer.
+     */
     private void showWKTString()
     {
         textArea.clear();
         textArea.setText(WKTString);
     }
 
+    /**
+     * Toggles the background color depending on current selection.
+     * @param val   BooleanProperty to evaluate.
+     */
     private void toggleBackgroundColor(final BooleanProperty val) {
         backgroundProperty().bind(Bindings.when(val)
                 .then(new Background(
@@ -146,70 +186,6 @@ public class Layer extends HBox {
                 .otherwise(new Background(
                         new BackgroundFill(Color.TRANSPARENT,
                                 CornerRadii.EMPTY, Insets.EMPTY))));
-    }
-
-    /**
-     * Creates a layer for this Layer object.
-     */
-    public final void createLayer() {
-
-        CheckBox cb = new CheckBox();
-        cb.setOnAction(event -> this.gisVis.toggleVisibility());
-
-        cb.setSelected(true);
-
-        //TODO style textfield with css so it looks like a label when not highlighted
-        TextField tf = new TextField(this.name + " " + gisVis.getID());
-
-        buttonUp = new Button("Up");
-        buttonUp.setOnAction(event -> {
-            moveSelectedLayers(1);
-            this.orderID--;
-            Layer.layers.get(this.orderID).setOrderID(this.orderID + 1);
-            reorderLayers();
-        });
-        buttonDown = new Button("Down");
-        buttonDown.setOnAction(event -> {
-            this.orderID++;
-            Layer.layers.get(this.orderID).setOrderID(this.orderID - 1);
-            reorderLayers();
-        });
-
-        //TODO style up and down but
-
-        VBox vb = new VBox();
-        //vb.getChildren().add(buttonUp);
-        //vb.getChildren().add(buttonDown);
-
-        this.getChildren().add(cb);
-        this.getChildren().add(tf);
-        this.getChildren().add(vb);
-    }
-
-    public final int getOrderID() {
-        return this.orderID;
-    }
-
-    public final void setOrderID(final int id) {
-        this.orderID = id;
-    }
-
-    /**
-     * Disable or enable the up button.
-     *
-     * @param b If True, disables button. Enables if false.
-     */
-    public final void setUpDisable(final boolean b) {
-        buttonUp.setDisable(b);
-    }
-
-    /**
-     * Disable or enable the down button.
-     *
-     * @param b If True, disables button. Enables if false.
-     */
-    public final void setDownDisable(final boolean b) {
-        buttonDown.setDisable(b);
     }
 
     /**
@@ -256,32 +232,58 @@ public class Layer extends HBox {
         reorderLayers();
     }
 
-
     /**
      * Reorders the layers according to their position in the layers list.
      */
     public final void reorderLayers() {
-        AnchorPane group = gisVis.getGroup();
+
+        redrawAll();
 
         this.parentContainer.getChildren().remove(0, this.parentContainer.getChildren().size());
-
-        group.getChildren().remove(0, group.getChildren().size());
-
-        //Redraw all the layers, only make the toplayer have tooltips
-        for (int i = layers.size() - 1; i >= 0; i--) {
-            Layer hb = layers.get(i);
-            hb.gisVis.reAddCanvas();
-            hb.gisVis.setDisplayTooltips(hb.isSelected.get());
-            hb.setUpDisable(false);
-            hb.setDownDisable(false);
-        }
 
         for (Layer layer : layers) {
             this.parentContainer.getChildren().add(layer);
         }
+    }
 
-        layers.get(0).setUpDisable(true);
-        layers.get(layers.size() - 1).setDownDisable(true);
+    /**
+     * Redraws all geometries to the canvas, in the same order as they appear in the layer view.
+     * The bottom layer is drawn at the bottom of the drawing stack.
+     */
+    public static void redrawAll()
+    {
+        GisVisualization.reset();
+
+        for (int i = layers.size() - 1; i >= 0; i--) {
+            Layer hb = layers.get(i);
+            if (hb.showOrHideCheckbox.isSelected()) {
+                hb.gisVis.create2DShapeAndTooltips();
+                hb.gisVis.setDisplayTooltips(hb.isSelected.get());
+            }
+        }
+    }
+
+    /**
+     * Checks or unchecks all the selected layers.
+     * This is useful for showing/hiding several layers at once.
+     */
+    private void checkShowOrHideCheckboxes()
+    {
+        if (isSelected.get()) {
+            boolean checkedValue = showOrHideCheckbox.isSelected();
+            for (Layer l : getAllSelectedLayers()) {
+                l.showOrHideCheckbox.setSelected(checkedValue);
+            }
+        }
+    }
+
+    public static ArrayList<Layer> getLayers() {
+        return layers;
+    }
+
+    public GisVisualization getGisVis()
+    {
+        return this.gisVis;
     }
 
 }

--- a/src/main/java/models/GeometryModel.java
+++ b/src/main/java/models/GeometryModel.java
@@ -1,7 +1,5 @@
 package models;
 
-
-
 import com.vividsolutions.jts.algorithm.CGAlgorithms;
 import com.vividsolutions.jts.geom.CoordinateSequence;
 import com.vividsolutions.jts.geom.LinearRing;
@@ -109,15 +107,14 @@ public abstract class GeometryModel {
         LinearRing shellR = new GeometryFactory().createLinearRing(shell);
 
         //Making the new polygon
-        Geometry p = new Polygon(shellR, holes, geometryFactory);
-        return p;
+        return new Polygon(shellR, holes, geometryFactory);
     }
 
     public final Geometry getOriginalGeometry() {
         return this.originalGeometry;
     }
 
-    public static final GeometryModel getModel(final Geometry geometry, final AnchorPane group) {
+    public static GeometryModel getModel(final Geometry geometry, final AnchorPane group) {
         if (geometry instanceof Polygon) {
             boolean hasHoles = ((Polygon) geometry).getNumInteriorRing() > 0;
             if (hasHoles) {
@@ -143,7 +140,6 @@ public abstract class GeometryModel {
         Circle circle = new Circle(x, y, TOOLTIP_SIZE, color);
         Tooltip tooltip = new Tooltip(x + ", " + y);
         Tooltip.install(circle, tooltip);
-        //this.group.getChildren().add(circle);
         return circle;
     }
 


### PR DESCRIPTION
_Disregard the previous one, I closed it, but not sure how to delete (like, make it go away.._poff_..because it never happened)_

This was a lot of work, especially doing all the merge conflicts. It should be okay now, but you should maybe take a look at it, because I changed ALOT.

I had to edit a few things with the zoom to get it to work with the new way everything works.

Redid mostly how everything in layer works. Now instead of a new canvas for each layer, everything is now drawn on the same. This will scale much better with more layers, and not result in Canvas throwing NullPointerExceptions when the accmulated canvas pixels exceed a certain limit.

Implemented WKT strings showing when a layer is selected. Area will be disabled if more than one is selected.

Fixed incorrect tooltip display with the new scale system
